### PR TITLE
Add `PlayerDamageByPlayerEvent`

### DIFF
--- a/api/src/main/java/xyz/srnyx/annoyingapi/AnnoyingPlugin.java
+++ b/api/src/main/java/xyz/srnyx/annoyingapi/AnnoyingPlugin.java
@@ -14,7 +14,7 @@ import xyz.srnyx.annoyingapi.command.AnnoyingCommand;
 import xyz.srnyx.annoyingapi.dependency.AnnoyingCommandRegister;
 import xyz.srnyx.annoyingapi.dependency.AnnoyingDependency;
 import xyz.srnyx.annoyingapi.dependency.AnnoyingDownload;
-import xyz.srnyx.annoyingapi.events.PlayerDamageByPlayerEvent;
+import xyz.srnyx.annoyingapi.events.EventHandlers;
 import xyz.srnyx.annoyingapi.file.AnnoyingResource;
 
 import java.util.*;
@@ -48,10 +48,10 @@ public class AnnoyingPlugin extends JavaPlugin {
     @NotNull public final Map<UUID, Map<AnnoyingCooldown.CooldownType, Long>> cooldowns = new HashMap<>();
 
     /**
-     * Constructs a new {@link AnnoyingPlugin} instance. Registers listeners for custom events
+     * Constructs a new {@link AnnoyingPlugin} instance. Registers event handlers for custom events
      */
     public AnnoyingPlugin() {
-        options.listeners.add(new PlayerDamageByPlayerEvent.EntityDamageByEntityListener(this));
+        options.listeners.add(new EventHandlers(this));
     }
 
     /**

--- a/api/src/main/java/xyz/srnyx/annoyingapi/AnnoyingPlugin.java
+++ b/api/src/main/java/xyz/srnyx/annoyingapi/AnnoyingPlugin.java
@@ -14,6 +14,7 @@ import xyz.srnyx.annoyingapi.command.AnnoyingCommand;
 import xyz.srnyx.annoyingapi.dependency.AnnoyingCommandRegister;
 import xyz.srnyx.annoyingapi.dependency.AnnoyingDependency;
 import xyz.srnyx.annoyingapi.dependency.AnnoyingDownload;
+import xyz.srnyx.annoyingapi.events.PlayerDamageByPlayerEvent;
 import xyz.srnyx.annoyingapi.file.AnnoyingResource;
 
 import java.util.*;
@@ -47,11 +48,10 @@ public class AnnoyingPlugin extends JavaPlugin {
     @NotNull public final Map<UUID, Map<AnnoyingCooldown.CooldownType, Long>> cooldowns = new HashMap<>();
 
     /**
-     * Constructs a new {@link AnnoyingPlugin} instance
-     * <p><i>Only exists to give the constructor a Javadoc</i>
+     * Constructs a new {@link AnnoyingPlugin} instance. Registers listeners for custom events
      */
     public AnnoyingPlugin() {
-        // Only exists to give the constructor a Javadoc
+        options.listeners.add(new PlayerDamageByPlayerEvent.EntityDamageByEntityListener(this));
     }
 
     /**

--- a/api/src/main/java/xyz/srnyx/annoyingapi/AnnoyingUtility.java
+++ b/api/src/main/java/xyz/srnyx/annoyingapi/AnnoyingUtility.java
@@ -27,6 +27,7 @@ public class AnnoyingUtility {
      * Constructs a new {@link AnnoyingUtility} instance
      * <p><i>Only exists to give the constructor a Javadoc</i>
      */
+    @Contract(pure = true)
     public AnnoyingUtility() {
         // Only exists to give the constructor a Javadoc
     }
@@ -103,7 +104,7 @@ public class AnnoyingUtility {
      *
      * @return          the translated message
      */
-    @NotNull @Contract("_ -> new")
+    @NotNull
     public static String color(@Nullable String message) {
         if (message == null) return "null";
         return ChatColor.translateAlternateColorCodes('&', message);

--- a/api/src/main/java/xyz/srnyx/annoyingapi/events/EventHandlers.java
+++ b/api/src/main/java/xyz/srnyx/annoyingapi/events/EventHandlers.java
@@ -1,0 +1,39 @@
+package xyz.srnyx.annoyingapi.events;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import xyz.srnyx.annoyingapi.AnnoyingListener;
+import xyz.srnyx.annoyingapi.AnnoyingPlugin;
+
+
+public class EventHandlers implements AnnoyingListener {
+    @NotNull
+    private final AnnoyingPlugin plugin;
+
+    @Contract(pure = true)
+    public EventHandlers(@NotNull AnnoyingPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @NotNull
+    public AnnoyingPlugin getPlugin() {
+        return plugin;
+    }
+
+    @EventHandler
+    public void onEntityDamageByEntity(@NotNull EntityDamageByEntityEvent event) {
+        final Entity damager = event.getDamager();
+        final Entity damagee = event.getEntity();
+        if (!(damager instanceof Player) || !(damagee instanceof Player)) return;
+        final PlayerDamageByPlayerEvent newEvent = new PlayerDamageByPlayerEvent((Player) damager, (Player) damagee, event.getCause(), event.getDamage());
+        Bukkit.getPluginManager().callEvent(newEvent);
+        event.setCancelled(newEvent.isCancelled());
+    }
+}

--- a/api/src/main/java/xyz/srnyx/annoyingapi/events/EventHandlers.java
+++ b/api/src/main/java/xyz/srnyx/annoyingapi/events/EventHandlers.java
@@ -13,10 +13,21 @@ import xyz.srnyx.annoyingapi.AnnoyingListener;
 import xyz.srnyx.annoyingapi.AnnoyingPlugin;
 
 
+/**
+ * Class for handling events for the API
+ */
 public class EventHandlers implements AnnoyingListener {
+    /**
+     * The plugin instance
+     */
     @NotNull
     private final AnnoyingPlugin plugin;
 
+    /**
+     * Instantiates a new {@link EventHandlers} for handling API events
+     *
+     * @param   plugin  the plugin instance
+     */
     @Contract(pure = true)
     public EventHandlers(@NotNull AnnoyingPlugin plugin) {
         this.plugin = plugin;
@@ -27,6 +38,13 @@ public class EventHandlers implements AnnoyingListener {
         return plugin;
     }
 
+    /**
+     * Called when an entity is damaged by an entity
+     *
+     * @param   event   the event
+     *
+     * @see             PlayerDamageByPlayerEvent
+     */
     @EventHandler
     public void onEntityDamageByEntity(@NotNull EntityDamageByEntityEvent event) {
         final Entity damager = event.getDamager();

--- a/api/src/main/java/xyz/srnyx/annoyingapi/events/PlayerDamageByPlayerEvent.java
+++ b/api/src/main/java/xyz/srnyx/annoyingapi/events/PlayerDamageByPlayerEvent.java
@@ -1,17 +1,12 @@
 package xyz.srnyx.annoyingapi.events;
 
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-
-import xyz.srnyx.annoyingapi.AnnoyingListener;
-import xyz.srnyx.annoyingapi.AnnoyingPlugin;
 
 
 public class PlayerDamageByPlayerEvent extends EntityDamageByEntityEvent {
@@ -21,37 +16,33 @@ public class PlayerDamageByPlayerEvent extends EntityDamageByEntityEvent {
         super(damager, damagee, cause, damage);
     }
 
-    @Contract(pure = true)
+    @NotNull @Contract(pure = true)
     public static HandlerList getHandlerList() {
         return HANDLERS;
     }
 
-    @Override
+    @Override @NotNull
     public HandlerList getHandlers() {
         return HANDLERS;
     }
 
-    public static class EntityDamageByEntityListener implements AnnoyingListener {
-        @NotNull private final AnnoyingPlugin plugin;
+    @Override @NotNull
+    public Player getDamager() {
+        return (Player) super.getDamager();
+    }
 
-        @Contract(pure = true)
-        public EntityDamageByEntityListener(@NotNull AnnoyingPlugin plugin) {
-            this.plugin = plugin;
-        }
+    @Override @NotNull
+    public Player getEntity() {
+        return (Player) super.getEntity();
+    }
 
-        @NotNull
-        public AnnoyingPlugin getPlugin() {
-            return plugin;
-        }
+    @Override @NotNull
+    public EntityType getEntityType() {
+        return EntityType.PLAYER;
+    }
 
-        @EventHandler
-        public void onEntityDamageByEntity(@NotNull EntityDamageByEntityEvent event) {
-            final Entity damager = event.getDamager();
-            final Entity damagee = event.getEntity();
-            if (!(damager instanceof Player) || !(damagee instanceof Player)) return;
-            final PlayerDamageByPlayerEvent newEvent = new PlayerDamageByPlayerEvent((Player) damager, (Player) damagee, event.getCause(), event.getDamage());
-            Bukkit.getPluginManager().callEvent(newEvent);
-            event.setCancelled(newEvent.isCancelled());
-        }
+    @NotNull
+    public Player getDamagee() {
+        return getEntity();
     }
 }

--- a/api/src/main/java/xyz/srnyx/annoyingapi/events/PlayerDamageByPlayerEvent.java
+++ b/api/src/main/java/xyz/srnyx/annoyingapi/events/PlayerDamageByPlayerEvent.java
@@ -1,0 +1,57 @@
+package xyz.srnyx.annoyingapi.events;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import xyz.srnyx.annoyingapi.AnnoyingListener;
+import xyz.srnyx.annoyingapi.AnnoyingPlugin;
+
+
+public class PlayerDamageByPlayerEvent extends EntityDamageByEntityEvent {
+    @NotNull private static final HandlerList HANDLERS = new HandlerList();
+
+    public PlayerDamageByPlayerEvent(@NotNull Player damager, @NotNull Player damagee, @NotNull DamageCause cause, double damage) {
+        super(damager, damagee, cause, damage);
+    }
+
+    @Contract(pure = true)
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static class EntityDamageByEntityListener implements AnnoyingListener {
+        @NotNull private final AnnoyingPlugin plugin;
+
+        @Contract(pure = true)
+        public EntityDamageByEntityListener(@NotNull AnnoyingPlugin plugin) {
+            this.plugin = plugin;
+        }
+
+        @NotNull
+        public AnnoyingPlugin getPlugin() {
+            return plugin;
+        }
+
+        @EventHandler
+        public void onEntityDamageByEntity(@NotNull EntityDamageByEntityEvent event) {
+            final Entity damager = event.getDamager();
+            final Entity damagee = event.getEntity();
+            if (!(damager instanceof Player) || !(damagee instanceof Player)) return;
+            final PlayerDamageByPlayerEvent newEvent = new PlayerDamageByPlayerEvent((Player) damager, (Player) damagee, event.getCause(), event.getDamage());
+            Bukkit.getPluginManager().callEvent(newEvent);
+            event.setCancelled(newEvent.isCancelled());
+        }
+    }
+}

--- a/api/src/main/java/xyz/srnyx/annoyingapi/events/PlayerDamageByPlayerEvent.java
+++ b/api/src/main/java/xyz/srnyx/annoyingapi/events/PlayerDamageByPlayerEvent.java
@@ -9,40 +9,86 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 
+/**
+ * This event is called when a {@link Player} damages another {@link Player}
+ */
 public class PlayerDamageByPlayerEvent extends EntityDamageByEntityEvent {
+    /**
+     * The {@link HandlerList} for this event.
+     */
     @NotNull private static final HandlerList HANDLERS = new HandlerList();
 
+    /**
+     * Instantiates a new {@link PlayerDamageByPlayerEvent}
+     *
+     * @param   damager the {@link Player} who damaged the {@code damagee}
+     * @param   damagee the {@link Player} who was damaged by the {@code damager}
+     * @param   cause   the {@link DamageCause} of the damage
+     * @param   damage  the amount of damage dealt
+     */
     public PlayerDamageByPlayerEvent(@NotNull Player damager, @NotNull Player damagee, @NotNull DamageCause cause, double damage) {
         super(damager, damagee, cause, damage);
     }
 
+    /**
+     * Returns the {@link HandlerList} for this event
+     *
+     * @return  {@link #HANDLERS}
+     */
     @NotNull @Contract(pure = true)
     public static HandlerList getHandlerList() {
         return HANDLERS;
     }
 
+    /**
+     * Returns the {@link HandlerList} for this event
+     *
+     * @return  {@link #HANDLERS}
+     */
     @Override @NotNull
     public HandlerList getHandlers() {
         return HANDLERS;
     }
 
+    /**
+     * Returns the {@link Player} that damaged the defender
+     *
+     * @return  {@link Player} that damaged the defender
+     */
     @Override @NotNull
     public Player getDamager() {
         return (Player) super.getDamager();
     }
 
+    /**
+     * Returns the {@link Player} who was damaged
+     *
+     * @return  {@link Player} who was damaged
+     */
     @Override @NotNull
     public Player getEntity() {
         return (Player) super.getEntity();
     }
 
-    @Override @NotNull
-    public EntityType getEntityType() {
-        return EntityType.PLAYER;
-    }
-
+    /**
+     * Same as {@link #getEntity()}, this is just an alias
+     *
+     * @return  {@link #getEntity()}
+     *
+     * @see     #getEntity()
+     */
     @NotNull
     public Player getDamagee() {
         return getEntity();
+    }
+
+    /**
+     * Will always return {@link EntityType#PLAYER}
+     *
+     * @return  {@link EntityType#PLAYER}
+     */
+    @Override @NotNull
+    public EntityType getEntityType() {
+        return EntityType.PLAYER;
     }
 }

--- a/api/src/main/resources/messages.yml
+++ b/api/src/main/resources/messages.yml
@@ -77,7 +77,7 @@ key4: "KDR: %kdr==#.##%" # %kdr==number%
 # --- END PLACEHOLDER PARAMETERS --- #
 
 
-# This message can be used to test practically anything!
+# This message can be used to test practically anything! FOR PLUGIN DEVELOPERS!
 test: "%prefix%This is a test message!"
 
 # Messages for general plugin usage

--- a/example-plugin/src/main/resources/msgs.yml
+++ b/example-plugin/src/main/resources/msgs.yml
@@ -81,7 +81,7 @@ key4: "KDR: %kdr==#.##%" # %kdr==decimal%
 # --- END PLACEHOLDER PARAMETERS --- #
 
 
-# This message can be used to test practically anything!
+# This message can be used to test practically anything! FOR PLUGIN DEVELOPERS!
 test: "%prefix%This is a test message!"
 
 # This will be what %prefix% is in all the other messages


### PR DESCRIPTION
## Description
Added the `PlayerDamageByPlayerEvent` event which will trigger when a player attacks another player (PVP). This event extends `EntityDamageByEntityEvent`

## Motivation and Context
This is a simple feature that just makes it easier to listen to PVP.

## How Has This Been Tested?
Tested by using another plugin and adding the PlayerDamageByPlayerEvent event handler. It works as intended.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
