### PR TITLE
Fix AttributeModifier serialization, download exception handling, selector nullability, and relocation package naming

### DIFF
--- a/src/main/java/xyz/srnyx/annoyingapi/AnnoyingPlugin.java
+++ b/src/main/java/xyz/srnyx/annoyingapi/AnnoyingPlugin.java
@@ -678,8 +678,13 @@ public class AnnoyingPlugin extends JavaPlugin {
      */
     @NotNull
     public Relocation getRelocation(@NotNull String from) {
-        final int index = from.contains("{}") ? from.lastIndexOf("{}") + 2 : (from.contains(".") ? from.lastIndexOf(".") + 1 : 0);
-        return getRelocation(from, from.substring(index).toLowerCase().replaceAll("[^a-z0-9._{}]", ""));
+        String name = from;
+        if (name.contains("{}")) {
+            name = name.substring(name.lastIndexOf("{}") + 2);
+        } else if (name.contains(".")) {
+            name = name.substring(name.lastIndexOf(".") + 1);
+        }
+        return getRelocation(from, name.toLowerCase().replaceAll("[^a-z0-9._{}]", ""));
     }
 
     /**

--- a/src/main/java/xyz/srnyx/annoyingapi/AnnoyingPlugin.java
+++ b/src/main/java/xyz/srnyx/annoyingapi/AnnoyingPlugin.java
@@ -678,7 +678,8 @@ public class AnnoyingPlugin extends JavaPlugin {
      */
     @NotNull
     public Relocation getRelocation(@NotNull String from) {
-        return getRelocation(from, from.substring(from.lastIndexOf("{}") + 2).toLowerCase().replaceAll("[^a-z0-9._{}]", ""));
+        final int index = from.contains("{}") ? from.lastIndexOf("{}") + 2 : (from.contains(".") ? from.lastIndexOf(".") + 1 : 0);
+        return getRelocation(from, from.substring(index).toLowerCase().replaceAll("[^a-z0-9._{}]", ""));
     }
 
     /**

--- a/src/main/java/xyz/srnyx/annoyingapi/command/selector/SelectorOptional.java
+++ b/src/main/java/xyz/srnyx/annoyingapi/command/selector/SelectorOptional.java
@@ -97,6 +97,7 @@ public record SelectorOptional<T>(@NotNull AnnoyingSender sender, @Nullable Stri
      */
     @Nullable @Unmodifiable
     public List<T> orElse(@NotNull Function<String, List<T>> other) {
+        if (raw == null) return null;
         if (selector == null) return other.apply(raw);
         final List<T> expanded = selector.expand(sender);
         if (expanded == null) sender.invalidArgument(raw);
@@ -112,6 +113,7 @@ public record SelectorOptional<T>(@NotNull AnnoyingSender sender, @Nullable Stri
      */
     @Nullable @Unmodifiable
     public List<T> orElseSingle(@NotNull Function<String, T> other) {
+        if (raw == null) return null;
         if (selector == null) return Collections.singletonList(other.apply(raw));
         final List<T> expanded = selector.expand(sender);
         if (expanded == null) sender.invalidArgument(raw);
@@ -127,6 +129,7 @@ public record SelectorOptional<T>(@NotNull AnnoyingSender sender, @Nullable Stri
      */
     @Nullable @Unmodifiable
     public List<T> orElseFlat(@NotNull Function<String, Optional<List<T>>> other) {
+        if (raw == null) return null;
         if (selector == null) {
             final Optional<List<T>> result = other.apply(raw);
             if (result.isEmpty()) sender.invalidArgument(raw);

--- a/src/main/java/xyz/srnyx/annoyingapi/dependency/AnnoyingDownload.java
+++ b/src/main/java/xyz/srnyx/annoyingapi/dependency/AnnoyingDownload.java
@@ -250,8 +250,9 @@ public class AnnoyingDownload extends AnnoyableClass {
             final byte[] buffer = new byte[1024];
             int numRead;
             while ((numRead = in.read(buffer)) != -1) out.write(buffer, 0, numRead);
-        } catch (final IOException ignored) {
-            //ignored
+        } catch (final IOException e) {
+            fail(dependency, platform);
+            return;
         }
 
         // Send success message

--- a/src/main/java/xyz/srnyx/annoyingapi/file/okaeri/serdes/AttributeModifierSerializer.java
+++ b/src/main/java/xyz/srnyx/annoyingapi/file/okaeri/serdes/AttributeModifierSerializer.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 import xyz.srnyx.annoyingapi.reflection.org.bukkit.attribute.RefAttributeModifier;
 
 import static xyz.srnyx.annoyingapi.reflection.org.bukkit.attribute.RefAttributeModifier.ATTRIBUTE_MODIFIER_CLASS;
+import static xyz.srnyx.annoyingapi.reflection.org.bukkit.attribute.RefAttributeModifier.ATTRIBUTE_MODIFIER_GET_AMOUNT_METHOD;
 import static xyz.srnyx.annoyingapi.reflection.org.bukkit.attribute.RefAttributeModifier.ATTRIBUTE_MODIFIER_GET_NAME_METHOD;
 import static xyz.srnyx.annoyingapi.reflection.org.bukkit.attribute.RefAttributeModifier.ATTRIBUTE_MODIFIER_GET_OPERATION_METHOD;
 import static xyz.srnyx.annoyingapi.reflection.org.bukkit.attribute.RefAttributeModifier.ATTRIBUTE_MODIFIER_GET_SLOT_GROUP_METHOD;
@@ -39,6 +40,13 @@ public class AttributeModifierSerializer implements ObjectSerializer<Object> {
         // name
         try {
             data.set("name", ATTRIBUTE_MODIFIER_GET_NAME_METHOD.invoke(object));
+        } catch (final Exception e) {
+            e.printStackTrace();
+        }
+
+        // amount
+        if (ATTRIBUTE_MODIFIER_GET_AMOUNT_METHOD != null) try {
+            data.set("amount", ATTRIBUTE_MODIFIER_GET_AMOUNT_METHOD.invoke(object));
         } catch (final Exception e) {
             e.printStackTrace();
         }

--- a/src/main/java/xyz/srnyx/annoyingapi/reflection/org/bukkit/attribute/RefAttributeModifier.java
+++ b/src/main/java/xyz/srnyx/annoyingapi/reflection/org/bukkit/attribute/RefAttributeModifier.java
@@ -50,6 +50,11 @@ public class RefAttributeModifier {
     @Nullable public static final Method ATTRIBUTE_MODIFIER_GET_NAME_METHOD = ReflectionUtility.getMethod(1, 13, 2, ATTRIBUTE_MODIFIER_CLASS, "getName");
 
     /**
+     * 1.13.2+ org.bukkit.attribute.AttributeModifier#getAmount()
+     */
+    @Nullable public static final Method ATTRIBUTE_MODIFIER_GET_AMOUNT_METHOD = ReflectionUtility.getMethod(1, 13, 2, ATTRIBUTE_MODIFIER_CLASS, "getAmount");
+
+    /**
      * 1.13.2+ org.bukkit.attribute.AttributeModifier#getOperation()
      */
     @Nullable public static final Method ATTRIBUTE_MODIFIER_GET_OPERATION_METHOD = ReflectionUtility.getMethod(1, 13, 2, ATTRIBUTE_MODIFIER_CLASS, "getOperation");


### PR DESCRIPTION
## Description
- **AttributeModifier Serialization:** Added `ATTRIBUTE_MODIFIER_GET_AMOUNT_METHOD` to `RefAttributeModifier` and updated `AttributeModifierSerializer#serialize` to write the required `"amount"` field during serialization.
- **Dependency Downloader Fail-Safe:** Updated `AnnoyingDownload#downloadFile` to catch `IOException` during stream operations, properly invoking `fail(dependency, platform)` to attempt fallback platforms instead of logging false success and loading corrupt/empty files.
- **Selector Optional Null Safety:** Added `raw == null` checks to `SelectorOptional#orElse`, `orElseSingle`, and `orElseFlat` to prevent passing `null` to `@NotNull Function` arguments when no input is supplied.
- **Relocation Package Parsing:** Updated `AnnoyingPlugin#getRelocation` to safely compute package name indices when standard dot-separated package strings (without `{}` delimiters) are provided.

## Motivation and Context
- Deserializing `AttributeModifier` objects failed with `IllegalArgumentException("Missing required field: amount")` due to missing serialization output.
- Failed network requests or interrupted downloads in `AnnoyingDownload` were swallowed silently, causing invalid JARs to be passed to Bukkit's plugin manager.
- Command selector resolution threw `NullPointerException` when evaluating default functions for absent command arguments.
- Standard package strings passed to `getRelocation` resulted in corrupted package target paths (e.g. `"org.reflections"` becoming `"rg.reflections"`).

## How Has This Been Tested?
- Executed unit test suite (`./gradlew test`) including `AttributeModifierSerializerTest`, `ConfigMigrationTest`, and storage dialect tests using MockBukkit.
- Verified round-trip serialization of `AttributeModifier` and valid handling of dependency download fallbacks.

## Media:
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.